### PR TITLE
おすすめ本アルゴリズムを著者×ジャンルの2軸検索に改善

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -140,19 +140,20 @@
 - 本の詳細ポップアップにも「登録から〇〇日」を表示
 
 ### 16. おすすめ本（レコメンデーション）
-- 読了した本の著者を基に「同じ著者の他の作品」を Google Books API で提案する
+- 読了した本の著者・ジャンルを分析し、Google Books API で関連作品を提案する
 - 本棚画面（`/bookshelf`）の棚エリア下部に「おすすめの本」セクションを表示
-  - セクション右上の「更新」ボタンで再取得可能（押すたびに別の著者の本が表示される）
+  - セクション右上の「更新」ボタンで再取得可能（押すたびに異なる著者・ジャンルの本が表示される）
   - 既に本棚に登録済みの本（`google_books_id` で照合）は除外して表示
-  - 表紙・タイトル・著者を横スクロールカードで最大10件表示
+  - 表紙・タイトル・著者を横スクロールカードで最大12件表示
   - カードをタップするとGoogle Books のページを新タブで開く
   - 読了本が0冊の場合は非表示
 - **レコメンドロジック**
-  - 読了本の著者一覧（重複除去）からランダムに1人選択
-  - API Route `/api/books/recommend` に著者名を渡し、サーバーサイドで `inauthor:著者名` クエリで Google Books API を呼び出す
+  - クライアント側で読了本の著者（上位3人）とジャンル（上位2つ）を出現頻度で集計
+  - 著者検索（`inauthor:著者名`）とジャンル検索（`subject:ジャンル`）を並行実行
+  - 2つの検索結果を統合・重複排除して返す
   - `langRestrict=ja` で日本語書籍に絞り込み
 - **コンポーネント**: `src/components/bookshelf/BookRecommendations.tsx`
-- **API Route**: `GET /api/books/recommend?author={著者名}&exclude={id1,id2}`
+- **API Route**: `GET /api/books/recommend?authors={著者1,著者2}&genres={ジャンル1}&exclude={id1,id2}`
 
 ### 17. 読書ヒートマップ（実装済み）
 - GitHub のコントリビューショングラフのように、今年1月1日〜12月31日の読書活動をカレンダー形式で可視化する
@@ -533,7 +534,7 @@ CREATE POLICY "reads_delete_own" ON book_reads FOR DELETE USING (user_id = auth.
 | メソッド | パス | 説明 |
 |---|---|---|
 | GET | `/api/books/search?q={query}` | Google Books API で本を検索して結果を返す |
-| GET | `/api/books/recommend?author={著者名}&exclude={id1,id2}` | 著者名でおすすめ本を最大10件返す（`inauthor:` 検索・日本語書籍限定） |
+| GET | `/api/books/recommend?authors={著者1,著者2}&genres={ジャンル1}&exclude={id1,id2}` | 著者×ジャンルの2軸並行検索でおすすめ本を最大12件返す（`inauthor:` + `subject:` 検索・日本語書籍限定） |
 
 > Google Books API キーはサーバーサイドの環境変数 `GOOGLE_BOOKS_API_KEY` から読み込む。クライアントには露出させない。
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -150,10 +150,10 @@
 - **レコメンドロジック**
   - クライアント側で読了本の著者（上位3人）とジャンル（上位2つ）を出現頻度で集計
   - 著者検索（`inauthor:著者名`）とジャンル検索（`subject:ジャンル`）を並行実行
-  - 2つの検索結果を統合・重複排除して返す
+  - 生成された検索クエリの結果を統合し、重複を排除して返す（ジャンル未設定時は著者検索のみ、両方空なら単一フォールバッククエリを実行）
   - `langRestrict=ja` で日本語書籍に絞り込み
 - **コンポーネント**: `src/components/bookshelf/BookRecommendations.tsx`
-- **API Route**: `GET /api/books/recommend?authors={著者1,著者2}&genres={ジャンル1}&exclude={id1,id2}`
+- **API Route**: `GET /api/books/recommend?authors={著者1}&authors={著者2}&genres={ジャンル1}&exclude={id1,id2}`（著者・ジャンルは同名パラメータの繰り返しで送信）
 
 ### 17. 読書ヒートマップ（実装済み）
 - GitHub のコントリビューショングラフのように、今年1月1日〜12月31日の読書活動をカレンダー形式で可視化する

--- a/src/app/api/books/recommend/route.ts
+++ b/src/app/api/books/recommend/route.ts
@@ -10,28 +10,49 @@ type GoogleBooksItem = {
   }
 }
 
+async function fetchByQuery(q: string, apiKey: string): Promise<GoogleBooksItem[]> {
+  const url = `https://www.googleapis.com/books/v1/volumes?q=${encodeURIComponent(q)}&maxResults=20&langRestrict=ja&orderBy=relevance&key=${apiKey}`
+  const res = await fetch(url, { next: { revalidate: 3600 } })
+  if (!res.ok) return []
+  const json = await res.json()
+  return json.items ?? []
+}
+
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url)
-  const author = searchParams.get('author') ?? ''
+  const authors = searchParams.get('authors')?.split(',').filter(Boolean) ?? []
+  const genres = searchParams.get('genres')?.split(',').filter(Boolean) ?? []
   const excludeIds = new Set(searchParams.get('exclude')?.split(',').filter(Boolean) ?? [])
 
-  const apiKey = process.env.GOOGLE_BOOKS_API_KEY
+  const apiKey = process.env.GOOGLE_BOOKS_API_KEY ?? ''
 
-  // 著者名で inauthor: 検索 → 同じ著者の別作品を提案
-  const q = author ? `inauthor:${author}` : '小説'
+  // 著者リストからランダムに1人、ジャンルリストからランダムに1つ選ぶ
+  const author = authors.length > 0
+    ? authors[Math.floor(Math.random() * Math.min(authors.length, 3))]
+    : null
+  const genre = genres.length > 0
+    ? genres[Math.floor(Math.random() * Math.min(genres.length, 2))]
+    : null
 
-  const url = `https://www.googleapis.com/books/v1/volumes?q=${encodeURIComponent(q)}&maxResults=20&langRestrict=ja&orderBy=relevance&key=${apiKey}`
+  // 著者検索・ジャンル検索を並行実行
+  const queries: string[] = []
+  if (author) queries.push(`inauthor:${author}`)
+  if (genre) queries.push(`subject:${genre}`)
+  if (queries.length === 0) queries.push('小説 日本')
 
-  const res = await fetch(url, { next: { revalidate: 3600 } })
-  if (!res.ok) {
-    return NextResponse.json({ error: 'Google Books API error' }, { status: 502 })
-  }
+  const results = await Promise.all(queries.map((q) => fetchByQuery(q, apiKey)))
+  const allItems = results.flat()
 
-  const json = await res.json()
-  const items: GoogleBooksItem[] = json.items ?? []
-
-  const results = items
-    .filter((item) => !excludeIds.has(item.id) && item.volumeInfo.title)
+  // 重複排除・除外済み本のフィルタリング
+  const seen = new Set<string>()
+  const filtered = allItems
+    .filter((item) => {
+      if (!item.volumeInfo?.title) return false
+      if (excludeIds.has(item.id)) return false
+      if (seen.has(item.id)) return false
+      seen.add(item.id)
+      return true
+    })
     .map((item) => ({
       google_books_id: item.id,
       title: item.volumeInfo.title ?? '',
@@ -41,7 +62,7 @@ export async function GET(request: Request) {
           ?.replace('http:', 'https:') ?? null,
       info_url: item.volumeInfo.infoLink ?? `https://books.google.com/books?id=${item.id}`,
     }))
-    .slice(0, 10)
+    .slice(0, 12)
 
-  return NextResponse.json(results)
+  return NextResponse.json(filtered)
 }

--- a/src/components/bookshelf/BookRecommendations.tsx
+++ b/src/components/bookshelf/BookRecommendations.tsx
@@ -17,6 +17,18 @@ type Props = {
   readBooks: Book[]
 }
 
+function getTopItems(books: Book[], key: 'author' | 'genre', limit: number): string[] {
+  const counts = new Map<string, number>()
+  for (const book of books) {
+    const val = book[key]
+    if (val) counts.set(val, (counts.get(val) ?? 0) + 1)
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([val]) => val)
+}
+
 export default function BookRecommendations({ readBooks }: Props) {
   const [books, setBooks] = useState<RecommendedBook[]>([])
   const [loading, setLoading] = useState(false)
@@ -24,18 +36,18 @@ export default function BookRecommendations({ readBooks }: Props) {
   const fetchRecommendations = useCallback(async () => {
     setLoading(true)
 
-    // 既読本の著者一覧（重複除去）をランダムに1人選ぶ → 「更新」のたびに違う著者の本が出る
-    const authors = [...new Set(readBooks.map((b) => b.author).filter(Boolean))]
-    const author = authors.length > 0 ? authors[Math.floor(Math.random() * authors.length)] : null
+    // 読書頻度が高い著者（上位3人）・ジャンル（上位2つ）を集計
+    const topAuthors = getTopItems(readBooks, 'author', 3)
+    const topGenres = getTopItems(readBooks, 'genre', 2)
 
-    // 既存の本を除外
     const excludeIds = readBooks
       .map((b) => b.google_books_id)
       .filter(Boolean)
       .join(',')
 
     const params = new URLSearchParams()
-    if (author) params.set('author', author)
+    if (topAuthors.length > 0) params.set('authors', topAuthors.join(','))
+    if (topGenres.length > 0) params.set('genres', topGenres.join(','))
     if (excludeIds) params.set('exclude', excludeIds)
 
     try {

--- a/src/components/bookshelf/BookRecommendations.tsx
+++ b/src/components/bookshelf/BookRecommendations.tsx
@@ -46,14 +46,18 @@ export default function BookRecommendations({ readBooks }: Props) {
       .join(',')
 
     const params = new URLSearchParams()
-    if (topAuthors.length > 0) params.set('authors', topAuthors.join(','))
-    if (topGenres.length > 0) params.set('genres', topGenres.join(','))
+    for (const a of topAuthors) params.append('authors', a)
+    for (const g of topGenres) params.append('genres', g)
     if (excludeIds) params.set('exclude', excludeIds)
 
     try {
       const res = await fetch(`/api/books/recommend?${params}`)
+      if (!res.ok) {
+        setBooks([])
+        return
+      }
       const data = await res.json()
-      setBooks(data)
+      setBooks(Array.isArray(data) ? data : [])
     } catch {
       // エラー時は空のまま
     } finally {
@@ -63,7 +67,7 @@ export default function BookRecommendations({ readBooks }: Props) {
 
   useEffect(() => {
     if (readBooks.length > 0) fetchRecommendations()
-  }, [fetchRecommendations, readBooks.length])
+  }, [fetchRecommendations])
 
   if (readBooks.length === 0) return null
 


### PR DESCRIPTION
## 指示内容
おすすめ本のアルゴリズムをちゃんとしたい。現状はランダムな著者1人で検索するだけなので、著者とジャンルの2軸で並行検索して多様なおすすめを表示できるようにしてほしい。

## 変更・作成ファイル

| ファイル | 変更種別 | 理由 |
|---|---|---|
| `src/app/api/books/recommend/route.ts` | 修正 | `authors`・`genres` パラメータを受け付け、著者検索とジャンル検索を並行実行して結果を統合するため |
| `src/components/bookshelf/BookRecommendations.tsx` | 修正 | 読了本から著者（上位3人）・ジャンル（上位2つ）を出現頻度で集計してAPIに送信するため |
| `SPEC.md` | 修正 | レコメンドロジックの仕様を実装に合わせて更新するため |

## 確認事項
- [x] `npx tsc --noEmit` でエラーなし
- [x] `npm run lint` でエラーなし
- [x] ローカルで動作確認済み

## 関連 Issue
Closes #3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  - おすすめ本セクションのレコメンドロジックを改善。読了本から著者上位3名とジャンル上位2つを分析し、より関連性の高い書籍を提案するように変更。
  - 推奨書籍の表示件数を最大12件に増加。

* **Documentation**
  - APIエンドポイント仕様ドキュメントを更新。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->